### PR TITLE
Refactor: Update Pino Logger Configuration and Dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,15 +10,14 @@
 	"dependencies": {
 		"@influxdata/influxdb-client": "^1.35.0",
 		"pino": "^9.6.0",
+		"pino-pretty": "^13.0.0",
 		"tibber-api": "^5.3.1"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.4",
 		"@tsconfig/node22": "^22.0.1",
 		"@types/node": "^22.14.0",
-		"@types/pino": "^7.0.5",
 		"dotenv": "^16.4.7",
-		"pino-pretty": "^13.0.0",
 		"tsx": "^4.19.3",
 		"typescript": "^5.8.3"
 	},
@@ -30,9 +29,16 @@
 		"format": "biome format --write",
 		"check": "biome check --write",
 		"test": "tsx --env-file=.env --test '**/*.test.{js,ts}' '**/*.spec.{js,ts}'",
-		"typecheck": "tsc --noEmit"
+		"typecheck": "tsc --noEmit",
+		"types": "tsc --noEmit"
 	},
-	"keywords": ["tibber", "influxdb", "iot", "power", "energy"],
+	"keywords": [
+		"tibber",
+		"influxdb",
+		"iot",
+		"power",
+		"energy"
+	],
 	"author": "Filip Lindqvist",
 	"license": "MIT",
 	"engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       pino:
         specifier: ^9.6.0
         version: 9.6.0
+      pino-pretty:
+        specifier: ^13.0.0
+        version: 13.0.0
       tibber-api:
         specifier: ^5.3.1
         version: 5.3.1
@@ -27,15 +30,9 @@ importers:
       '@types/node':
         specifier: ^22.14.0
         version: 22.14.0
-      '@types/pino':
-        specifier: ^7.0.5
-        version: 7.0.5
       dotenv:
         specifier: ^16.4.7
         version: 16.4.7
-      pino-pretty:
-        specifier: ^13.0.0
-        version: 13.0.0
       tsx:
         specifier: ^4.19.3
         version: 4.19.3
@@ -256,10 +253,6 @@ packages:
 
   '@types/node@22.14.0':
     resolution: {integrity: sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==}
-
-  '@types/pino@7.0.5':
-    resolution: {integrity: sha512-wKoab31pknvILkxAF8ss+v9iNyhw5Iu/0jLtRkUD74cNfOOLJNnqfFKAv0r7wVaTQxRZtWrMpGfShwwBjOcgcg==}
-    deprecated: This is a stub types definition. pino provides its own type definitions, so you do not need this installed.
 
   atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
@@ -519,10 +512,6 @@ snapshots:
   '@types/node@22.14.0':
     dependencies:
       undici-types: 6.21.0
-
-  '@types/pino@7.0.5':
-    dependencies:
-      pino: 9.6.0
 
   atomic-sleep@1.0.0: {}
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -7,20 +7,34 @@ const logFormat = process.env.LOG_FORMAT?.toLowerCase(); // Read and normalize
 // Default: pretty in dev, json in prod
 const usePrettyPrint = logFormat === "pretty" || (!logFormat && !isProduction);
 const usePlainPrint = logFormat === "plain";
-const enableTransport = usePrettyPrint || usePlainPrint;
+
+const transport = (() => {
+	if (usePrettyPrint || usePlainPrint) {
+		return pino.transport({
+			target: "pino-pretty",
+			options: {
+				colorize: usePrettyPrint,
+				ignore: "pid,hostname,node",
+			},
+		});
+	}
+	return undefined;
+})();
 
 const logger = pino({
 	level: process.env.LOG_LEVEL || (isProduction ? "info" : "debug"),
-	transport: enableTransport
-		? {
-				target: "pino-pretty",
-				options: {
-					colorize: usePrettyPrint, // Only colorize if format is 'pretty'
-					translateTime: "SYS:standard",
-					ignore: "pid,hostname",
-				},
-			}
-		: undefined,
+	transport,
+	timestamp: pino.stdTimeFunctions.isoTime,
+	formatters: {
+		bindings: (bindings) => {
+			return {
+				node: process.version,
+			};
+		},
+		level: (label) => {
+			return { level: label.toUpperCase() };
+		},
+	},
 });
 
 export default logger;


### PR DESCRIPTION
This PR refactors the logger setup and updates related dependencies.

Changes include:

- Moved `pino-pretty` to `dependencies` as it's used by the runtime transport.
- Removed deprecated `@types/pino`.
- Refactored logger initialization in `src/logger.ts` for clarity, separating transport configuration logic.
- Added standard ISO timestamp formatting.
- Added custom formatters for log level (uppercase) and bindings (Node.js version).
- Minor formatting updates in `package.json`.