### PR TITLE
Feat: Adjust InfluxDB write log levels

### DIFF
--- a/src/influxdb.ts
+++ b/src/influxdb.ts
@@ -41,10 +41,10 @@ class InfluxDB {
 				minRetryDelay: 1000,
 				flushInterval: 10000,
 				writeSuccess(lines) {
-					logger.info("Write successful!", { lines });
+					logger.debug("Write successful!", { lines });
 				},
 				writeFailed(error, lines, attempt, expires) {
-					logger.error("Write failed:", error, { lines, attempt, expires });
+					logger.warn("Write failed:", error, { lines, attempt, expires });
 				},
 			},
 		);


### PR DESCRIPTION
This PR adjusts the log levels for InfluxDB write operations:

- Changes successful write logs from `info` to `debug` to reduce verbosity during normal operation.
- Changes failed write logs from `error` to `warn` as failures might be transient and recoverable.

Addresses potential log spam mentioned in #XX (if applicable, replace XX with issue number).