### PR TITLE
Remove deprecated INFLUXDB_ORG references

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ Configure the application using environment variables in the `docker-compose.yml
 
 - `INFLUXDB_URL`: InfluxDB server URL (default: http://influxdb:8086)
 - `INFLUXDB_TOKEN`: InfluxDB authentication token (required)
-- `INFLUXDB_ORG`: InfluxDB organization (deprecated - not used with InfluxDB v3)
 - `INFLUXDB_BUCKET`: InfluxDB bucket/database to store data (default: tibber)
 - `INFLUXDB_MEASUREMENT`: InfluxDB mesurement to store data (default: live_data)
 
@@ -57,7 +56,6 @@ Configure the application using environment variables in the `docker-compose.yml
 
    INFLUXDB_URL=http://influx-url:8086/
    INFLUXDB_TOKEN=your-token
-   INFLUXDB_ORG=your-org
    INFLUXDB_BUCKET=your-bucket
    INFLUXDB_MEASUREMENT=your-measurment
    ```

--- a/src/app.ts
+++ b/src/app.ts
@@ -10,7 +10,6 @@ interface Config {
 	feedConnectionTimeout?: number;
 	influxUrl: string;
 	influxToken: string;
-	influxOrg: string;
 	influxBucket: string;
 	influxMeasurement: string;
 }
@@ -27,7 +26,6 @@ const config: Config = {
 	// InfluxDB configuration
 	influxUrl: process.env.INFLUXDB_URL || "http://localhost:8086",
 	influxToken: process.env.INFLUXDB_TOKEN || "",
-	influxOrg: process.env.INFLUXDB_ORG || "my-org",
 	influxBucket: process.env.INFLUXDB_BUCKET || "tibber",
 	influxMeasurement: process.env.INFLUXDB_MEASUREMENT || "live_data",
 };

--- a/src/tibber-data-fetcher.ts
+++ b/src/tibber-data-fetcher.ts
@@ -12,7 +12,6 @@ interface TibberConfig {
 	feedConnectionTimeout?: number;
 	influxUrl: string;
 	influxToken: string;
-	influxOrg: string;
 	influxBucket: string;
 	influxMeasurement: string;
 }


### PR DESCRIPTION
Remove the deprecated org field from configuration interfaces and environment variables. The org concept is not used in InfluxDB v3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)