### PR TITLE
feat: Backfill, auth on health endpoint, log tweaks

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,21 @@
+TIBBER_ACCESS_TOKEN=
+TIBBER_HOME_ID=
+TIBBER_QUERY_URL=https://api.tibber.com/v1-beta/gql
+TIBBER_FEED_TIMEOUT=120
+TIBBER_CONNECTION_TIMEOUT=60
+
+INFLUXDB_URL=
+INFLUXDB_TOKEN=
+INFLUXDB_ORG=
+INFLUXDB_BUCKET=
+INFLUXDB_MEASUREMENT=tibber
+
+LOG_FORMAT=pretty
+LOG_LEVEL=debug
+
+# Set to an ISO date (e.g. 2024-01-01) to backfill hourly consumption data from that date to now
+BACKFILL_FROM_DATE=
+# Number of hourly records fetched per API request
+BACKFILL_PAGE_SIZE=100
+# Delay in ms between API calls (rate limiting)
+BACKFILL_DELAY_MS=5000

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ Configure the application using environment variables in the `docker-compose.yml
 
 - `INFLUXDB_URL`: InfluxDB server URL (default: http://influxdb:8086)
 - `INFLUXDB_TOKEN`: InfluxDB authentication token (required)
-- `INFLUXDB_ORG`: InfluxDB organization (deprecated - not used with InfluxDB v3)
 - `INFLUXDB_BUCKET`: InfluxDB bucket/database to store data (default: tibber)
 - `INFLUXDB_MEASUREMENT`: InfluxDB mesurement to store data (default: live_data)
 
@@ -57,7 +56,6 @@ Configure the application using environment variables in the `docker-compose.yml
 
    INFLUXDB_URL=http://influx-url:8086/
    INFLUXDB_TOKEN=your-token
-   INFLUXDB_ORG=your-org
    INFLUXDB_BUCKET=your-bucket
    INFLUXDB_MEASUREMENT=your-measurment
    ```

--- a/src/app.ts
+++ b/src/app.ts
@@ -10,7 +10,6 @@ interface Config {
 	feedConnectionTimeout?: number;
 	influxUrl: string;
 	influxToken: string;
-	influxOrg: string;
 	influxBucket: string;
 	influxMeasurement: string;
 }
@@ -27,7 +26,6 @@ const config: Config = {
 	// InfluxDB configuration
 	influxUrl: process.env.INFLUXDB_URL || "http://localhost:8086",
 	influxToken: process.env.INFLUXDB_TOKEN || "",
-	influxOrg: process.env.INFLUXDB_ORG || "my-org",
 	influxBucket: process.env.INFLUXDB_BUCKET || "tibber",
 	influxMeasurement: process.env.INFLUXDB_MEASUREMENT || "live_data",
 };

--- a/src/backfill.ts
+++ b/src/backfill.ts
@@ -1,0 +1,211 @@
+import type { TibberQuery } from "tibber-api";
+import type InfluxDB from "./influxdb";
+import logger from "./logger";
+
+interface BackfillConfig {
+	homeId: string;
+	measurement: string;
+	fromDate: string;
+	pageSize: number;
+	delayMs: number;
+}
+
+interface ConsumptionNode {
+	from: string;
+	to: string;
+	consumption: number | null;
+	cost: number | null;
+	currency: string;
+	unitPrice: number | null;
+	unitPriceVAT: number | null;
+	totalCost: number | null;
+	unitCost: number | null;
+	consumptionUnit: string;
+}
+
+interface ConsumptionPage {
+	pageInfo: { hasNextPage: boolean; endCursor: string | null };
+	nodes: ConsumptionNode[];
+}
+
+function buildQuery(homeId: string, first: number, after: string): string {
+	return `{
+		viewer {
+			home(id: "${homeId}") {
+				consumption(resolution: HOURLY, first: ${first}, after: "${after}") {
+					pageInfo {
+						hasNextPage
+						endCursor
+					}
+					nodes {
+						from
+						to
+						consumption
+						cost
+						currency
+						unitPrice
+						unitPriceVAT
+						totalCost
+						unitCost
+						consumptionUnit
+					}
+				}
+			}
+		}
+	}`;
+}
+
+function toCursor(isoDate: string): string {
+	return Buffer.from(isoDate).toString("base64");
+}
+
+function sleep(ms: number, signal: AbortSignal): Promise<void> {
+	return new Promise((resolve, reject) => {
+		if (signal.aborted) {
+			reject(signal.reason);
+			return;
+		}
+		const timer = setTimeout(resolve, ms);
+		signal.addEventListener(
+			"abort",
+			() => {
+				clearTimeout(timer);
+				reject(signal.reason);
+			},
+			{ once: true },
+		);
+	});
+}
+
+async function getResumeTimestamp(
+	influxDb: InfluxDB,
+	measurement: string,
+): Promise<string | null> {
+	try {
+		const rows = await influxDb.query(
+			`SELECT MAX(time) as last_time FROM "${measurement}" WHERE "accumulatedConsumptionLastHour" IS NOT NULL`,
+		);
+		if (rows.length > 0 && rows[0].last_time) {
+			const ts =
+				rows[0].last_time instanceof Date
+					? rows[0].last_time.toISOString()
+					: String(rows[0].last_time);
+			logger.info({ resumeFrom: ts }, "Backfill resuming from last checkpoint");
+			return ts;
+		}
+	} catch (error) {
+		logger.warn({ error }, "Could not query resume timestamp, starting fresh");
+	}
+	return null;
+}
+
+export async function startBackfill(
+	tibberQuery: TibberQuery,
+	influxDb: InfluxDB,
+	config: BackfillConfig,
+	signal: AbortSignal,
+): Promise<void> {
+	const log = logger.child({ module: "backfill" });
+
+	const resumeTs = await getResumeTimestamp(influxDb, config.measurement);
+	let cursor = toCursor(resumeTs ?? config.fromDate);
+
+	log.info(
+		{
+			fromDate: config.fromDate,
+			resumeFrom: resumeTs,
+			pageSize: config.pageSize,
+			delayMs: config.delayMs,
+		},
+		"Starting historical backfill",
+	);
+
+	let totalWritten = 0;
+
+	while (!signal.aborted) {
+		const query = buildQuery(config.homeId, config.pageSize, cursor);
+
+		let result: any;
+		try {
+			result = await tibberQuery.execute(query);
+		} catch (error) {
+			log.error({ error }, "Backfill API request failed");
+			await sleep(config.delayMs, signal);
+			continue;
+		}
+
+		const consumption: ConsumptionPage | undefined =
+			result?.viewer?.home?.consumption;
+
+		if (!consumption || !consumption.nodes || consumption.nodes.length === 0) {
+			log.info("Backfill complete: no more data");
+			break;
+		}
+
+		// Track running totals for accumulated fields
+		let currentDay: string | null = null;
+		let accumulatedConsumption = 0;
+		let accumulatedCost = 0;
+
+		for (const node of consumption.nodes) {
+			if (signal.aborted) break;
+			if (node.consumption === null) continue;
+
+			const nodeDay = node.from.slice(0, 10);
+
+			// Reset accumulators at midnight boundary
+			if (nodeDay !== currentDay) {
+				currentDay = nodeDay;
+				accumulatedConsumption = 0;
+				accumulatedCost = 0;
+			}
+
+			accumulatedConsumption += node.consumption ?? 0;
+			accumulatedCost += node.cost ?? 0;
+
+			const point: { timestamp: string; [key: string]: any } = {
+				timestamp: node.from,
+				accumulatedConsumptionLastHour: node.consumption,
+				accumulatedConsumption,
+				accumulatedCost,
+				currency: node.currency,
+			};
+
+			if (node.cost !== null) point.cost = node.cost;
+			if (node.unitPrice !== null) point.unitPrice = node.unitPrice;
+			if (node.unitPriceVAT !== null) point.unitPriceVAT = node.unitPriceVAT;
+			if (node.totalCost !== null) point.totalCost = node.totalCost;
+			if (node.unitCost !== null) point.unitCost = node.unitCost;
+			if (node.consumptionUnit) point.consumptionUnit = node.consumptionUnit;
+
+			await influxDb.writePoint(config.measurement, point);
+			totalWritten++;
+		}
+
+		log.info(
+			{
+				pageNodes: consumption.nodes.length,
+				totalWritten,
+				hasNextPage: consumption.pageInfo.hasNextPage,
+			},
+			"Backfill page processed",
+		);
+
+		if (!consumption.pageInfo.hasNextPage) {
+			log.info({ totalWritten }, "Backfill complete: all pages fetched");
+			break;
+		}
+
+		cursor = consumption.pageInfo.endCursor ?? cursor;
+
+		try {
+			await sleep(config.delayMs, signal);
+		} catch {
+			break;
+		}
+	}
+
+	if (signal.aborted) {
+		log.info({ totalWritten }, "Backfill aborted");
+	}
+}

--- a/src/influxdb.ts
+++ b/src/influxdb.ts
@@ -45,7 +45,11 @@ class InfluxDB {
 			logger.debug("Testing connection to InfluxDB...");
 
 			// Simple health check
-			const response = await fetch(`${this.config.host}/health`);
+			const response = await fetch(`${this.config.host}/health`, {
+				headers: {
+					Authorization: `Bearer ${this.config.token}`,
+				},
+			});
 
 			if (response.ok) {
 				logger.debug("Successfully connected to InfluxDB");
@@ -115,6 +119,14 @@ class InfluxDB {
 			logger.error({ error, measurement }, "Failed to write data to InfluxDB");
 			return false;
 		}
+	}
+
+	async query(sql: string): Promise<Record<string, any>[]> {
+		const rows: Record<string, any>[] = [];
+		for await (const row of this.client.query(sql, this.config.database)) {
+			rows.push(row);
+		}
+		return rows;
 	}
 
 	async close(): Promise<boolean> {

--- a/src/tibber-data-fetcher.ts
+++ b/src/tibber-data-fetcher.ts
@@ -12,7 +12,6 @@ interface TibberConfig {
 	feedConnectionTimeout?: number;
 	influxUrl: string;
 	influxToken: string;
-	influxOrg: string;
 	influxBucket: string;
 	influxMeasurement: string;
 }


### PR DESCRIPTION
## Summary

- Add historical consumption data backfill from Tibber GraphQL API with resume support, rate limiting, and field mapping aligned to the live feed
- Add Authorization header on InfluxDB health endpoint
- Support for flight service
- Remove deprecated INFLUXDB_ORG references
- Log tweaks

🤖 Generated with [Claude Code](https://claude.com/claude-code)