### PR TITLE
Fix backfill: replace non-existent execute() with query()

### DIFF
--- a/src/backfill.ts
+++ b/src/backfill.ts
@@ -138,7 +138,7 @@ export async function startBackfill(
 
 		let result: any;
 		try {
-			result = await tibberQuery.execute(query);
+			result = await tibberQuery.query(query);
 		} catch (error) {
 			log.error({ err: error }, "Backfill API request failed");
 			await sleep(config.delayMs, signal);

--- a/src/types/tibber-api.d.ts
+++ b/src/types/tibber-api.d.ts
@@ -16,7 +16,7 @@ declare module "tibber-api" {
 
 	class TibberQuery {
 		constructor(config: TibberQueryConfig);
-		execute(query: string, variables?: Record<string, any>): Promise<any>;
+		query(query: string, variables?: Record<string, any>): Promise<any>;
 	}
 
 	class TibberFeed extends NodeJS.EventEmitter {


### PR DESCRIPTION
The `tibber-api` package's `TibberQuery` class doesn't have an `execute()` method. The correct method is `query()`, inherited from `TibberQueryBase`.

This fix changes both the backfill call site and the local type declaration to use the correct API method.

- Fixes `src/backfill.ts:141` to call `query()` instead of `execute()`
- Updates type declaration in `src/types/tibber-api.d.ts` to match the real API